### PR TITLE
include pymacaroons tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/**
+package-lock.json

--- a/gomacaroon-v1.go
+++ b/gomacaroon-v1.go
@@ -7,15 +7,15 @@ import (
 	"gopkg.in/macaroon.v1"
 )
 
-type goMacaroon struct {
+type goMacaroonV1 struct {
 	*macaroon.Macaroon
 }
 
-func (m goMacaroon) clone() goMacaroon {
-	return goMacaroon{m.Macaroon.Clone()}
+func (m goMacaroonV1) clone() goMacaroonV1 {
+	return goMacaroonV1{m.Macaroon.Clone()}
 }
 
-func (m goMacaroon) WithFirstPartyCaveat(caveatId string) (Macaroon, error) {
+func (m goMacaroonV1) WithFirstPartyCaveat(caveatId string) (Macaroon, error) {
 	m = m.clone()
 	if err := m.Macaroon.AddFirstPartyCaveat(caveatId); err != nil {
 		return nil, err
@@ -23,7 +23,7 @@ func (m goMacaroon) WithFirstPartyCaveat(caveatId string) (Macaroon, error) {
 	return m, nil
 }
 
-func (m goMacaroon) WithThirdPartyCaveat(rootKey []byte, caveatId string, loc string) (Macaroon, error) {
+func (m goMacaroonV1) WithThirdPartyCaveat(rootKey []byte, caveatId string, loc string) (Macaroon, error) {
 	m = m.clone()
 	if err := m.Macaroon.AddThirdPartyCaveat(rootKey, caveatId, loc); err != nil {
 		return nil, err
@@ -31,42 +31,42 @@ func (m goMacaroon) WithThirdPartyCaveat(rootKey []byte, caveatId string, loc st
 	return m, nil
 }
 
-func (m goMacaroon) Bind(primary Macaroon) (Macaroon, error) {
+func (m goMacaroonV1) Bind(primary Macaroon) (Macaroon, error) {
 	m = m.clone()
 	m.Macaroon.Bind(primary.Signature())
 	return m, nil
 }
 
-func (m goMacaroon) Verify(rootKey []byte, check Checker, discharges []Macaroon) error {
+func (m goMacaroonV1) Verify(rootKey []byte, check Checker, discharges []Macaroon) error {
 	discharges1 := make([]*macaroon.Macaroon, len(discharges))
 	for i, m := range discharges {
-		discharges1[i] = m.(goMacaroon).Macaroon
+		discharges1[i] = m.(goMacaroonV1).Macaroon
 	}
 	return m.Macaroon.Verify(rootKey, check.Check, discharges1)
 }
 
-type goMacaroonPackage struct{}
+type goMacaroonV1Package struct{}
 
-func (goMacaroonPackage) New(rootKey []byte, id, loc string) (Macaroon, error) {
+func (goMacaroonV1Package) New(rootKey []byte, id, loc string) (Macaroon, error) {
 	m, err := macaroon.New(rootKey, id, loc)
 	if err != nil {
 		return nil, err
 	}
-	return goMacaroon{m}, nil
+	return goMacaroonV1{m}, nil
 }
 
-func (goMacaroonPackage) UnmarshalJSON(data []byte) (Macaroon, error) {
+func (goMacaroonV1Package) UnmarshalJSON(data []byte) (Macaroon, error) {
 	var m macaroon.Macaroon
 	if err := m.UnmarshalJSON(data); err != nil {
 		return nil, err
 	}
-	return goMacaroon{&m}, nil
+	return goMacaroonV1{&m}, nil
 }
 
-func (goMacaroonPackage) UnmarshalBinary(data []byte) (Macaroon, error) {
+func (goMacaroonV1Package) UnmarshalBinary(data []byte) (Macaroon, error) {
 	var m macaroon.Macaroon
 	if err := m.UnmarshalBinary(data); err != nil {
 		return nil, err
 	}
-	return goMacaroon{&m}, nil
+	return goMacaroonV1{&m}, nil
 }

--- a/gomacaroon-v2.go
+++ b/gomacaroon-v2.go
@@ -1,0 +1,72 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPL, see LICENCE file for details.
+
+package macarooncompat
+
+import (
+	"gopkg.in/macaroon.v2-unstable"
+)
+
+type goMacaroonV2 struct {
+	*macaroon.Macaroon
+}
+
+func (m goMacaroonV2) clone() goMacaroonV2 {
+	return goMacaroonV2{m.Macaroon.Clone()}
+}
+
+func (m goMacaroonV2) WithFirstPartyCaveat(caveatId string) (Macaroon, error) {
+	m = m.clone()
+	if err := m.Macaroon.AddFirstPartyCaveat(caveatId); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m goMacaroonV2) WithThirdPartyCaveat(rootKey []byte, caveatId string, loc string) (Macaroon, error) {
+	m = m.clone()
+	if err := m.Macaroon.AddThirdPartyCaveat(rootKey, []byte(caveatId), loc); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m goMacaroonV2) Bind(primary Macaroon) (Macaroon, error) {
+	m = m.clone()
+	m.Macaroon.Bind(primary.Signature())
+	return m, nil
+}
+
+func (m goMacaroonV2) Verify(rootKey []byte, check Checker, discharges []Macaroon) error {
+	discharges1 := make([]*macaroon.Macaroon, len(discharges))
+	for i, m := range discharges {
+		discharges1[i] = m.(goMacaroonV2).Macaroon
+	}
+	return m.Macaroon.Verify(rootKey, check.Check, discharges1)
+}
+
+type goMacaroonV2Package struct{}
+
+func (goMacaroonV2Package) New(rootKey []byte, id, loc string) (Macaroon, error) {
+	m, err := macaroon.New(rootKey, []byte(id), loc, macaroon.V1)
+	if err != nil {
+		return nil, err
+	}
+	return goMacaroonV2{m}, nil
+}
+
+func (goMacaroonV2Package) UnmarshalJSON(data []byte) (Macaroon, error) {
+	var m macaroon.Macaroon
+	if err := m.UnmarshalJSON(data); err != nil {
+		return nil, err
+	}
+	return goMacaroonV2{&m}, nil
+}
+
+func (goMacaroonV2Package) UnmarshalBinary(data []byte) (Macaroon, error) {
+	var m macaroon.Macaroon
+	if err := m.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return goMacaroonV2{&m}, nil
+}

--- a/interface.go
+++ b/interface.go
@@ -12,7 +12,7 @@ type Macaroon interface {
 	MarshalBinary() ([]byte, error)
 	WithFirstPartyCaveat(caveatId string) (Macaroon, error)
 	WithThirdPartyCaveat(rootKey []byte, caveatId string, loc string) (Macaroon, error)
-	Bind(discharge Macaroon) (Macaroon, error)
+	Bind(primary Macaroon) (Macaroon, error)
 	Verify(rootKey []byte, check Checker, discharges []Macaroon) error
 	Signature() []byte
 }
@@ -35,21 +35,41 @@ type Package interface {
 type Implementation string
 
 const (
-	ImplGo           Implementation = "go"
-	ImplLibMacaroons Implementation = "libmacaroons"
-	ImplJSMacaroon   Implementation = "jsmacaroon"
+	ImplGoV1          Implementation = "gov1"
+	ImplGoV2          Implementation = "gov2"
+	ImplLibMacaroons2 Implementation = "libmacaroons2"
+	ImplJSMacaroon    Implementation = "jsmacaroon"
+	ImplPyMacaroons2  Implementation = "pymacaroons2"
+	ImplPyMacaroons3  Implementation = "pymacaroons3"
 )
 
 var Implementations = []struct {
 	Name Implementation
 	Pkg  Package
 }{{
-	Name: ImplGo,
-	Pkg:  goMacaroonPackage{},
+	Name: ImplGoV1,
+	Pkg:  goMacaroonV1Package{},
 }, {
-	Name: ImplLibMacaroons,
-	Pkg:  libMacaroonPkg{},
+	Name: ImplGoV2,
+	Pkg:  goMacaroonV2Package{},
+}, {
+	Name: ImplLibMacaroons2,
+	Pkg: libMacaroonsPkg{
+		version: 2,
+	},
 }, {
 	Name: ImplJSMacaroon,
 	Pkg:  jsMacaroonPkg{},
+}, {
+	Name: ImplPyMacaroons2,
+	Pkg: pyMacaroonsPkg{
+		version: 2,
+	},
+}, {
+	Name: ImplPyMacaroons3,
+	Pkg: pyMacaroonsPkg{
+		version: 3,
+	},
 }}
+
+// TODO add libmacaroons python 3.

--- a/interp.go
+++ b/interp.go
@@ -1,0 +1,165 @@
+package macarooncompat
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	errgo "gopkg.in/errgo.v1"
+)
+
+type pyInterp struct {
+	interp *interp
+}
+
+// newPyInterp returns an interpreter instance that will run the
+// given python version (either 2 or 3).
+func newPyInterp(version int) *pyInterp {
+	return &pyInterp{
+		interp: newInterp(fmt.Sprintf("python%d", version), "./python/interp.py"),
+	}
+}
+
+func (i *pyInterp) eval(expr string, resultVal interface{}) error {
+	if err := i.start(); err != nil {
+		return fmt.Errorf("cannot start pyinterp: %v", err)
+	}
+	return i.interp.eval(expr, resultVal)
+}
+
+func (i *pyInterp) started() bool {
+	return i.interp.started()
+}
+
+func (i *pyInterp) start() error {
+	if i.started() {
+		return nil
+	}
+	if err := i.interp.start(); err != nil {
+		return errgo.Mask(err)
+	}
+	var r bool
+	if err := i.interp.eval("result=True", &r); err != nil {
+		return fmt.Errorf("sanity check failed: %v", err)
+	}
+	return nil
+}
+
+var pyNameSeq = 0
+
+func newPyName(s string) string {
+	n := pyNameSeq
+	pyNameSeq++
+	return fmt.Sprintf("%s%d", s, n)
+}
+
+func pyImportSym(imp string) string {
+	return strings.Split(imp, ".")[0]
+}
+
+func pyVal(v interface{}) string {
+	switch v := v.(type) {
+	case string:
+		return fmt.Sprintf("%q", v)
+	case []byte:
+		return fmt.Sprintf(`base64.b64decode(%q)`, base64.StdEncoding.EncodeToString(v))
+	case int, float64:
+		return fmt.Sprint(v)
+	default:
+		panic(errgo.Newf("cannot encode value %v of type %T", v, v))
+	}
+}
+
+type interp struct {
+	cmd    string
+	args   []string
+	stdin  io.Writer
+	stdout *bufio.Scanner
+}
+
+func newInterp(cmd string, args ...string) *interp {
+	return &interp{
+		cmd:  cmd,
+		args: args,
+	}
+}
+
+func (i *interp) started() bool {
+	return i.stdin != nil
+}
+
+func (i *interp) start() error {
+	if i.started() {
+		return nil
+	}
+	log.Printf("starting %q %q", i.cmd, i.args)
+	cmd := exec.Command(i.cmd, i.args...)
+	cmd.Stderr = os.Stderr
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	i.stdin = stdin
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		i.stdin = nil
+		return err
+	}
+	i.stdout = bufio.NewScanner(stdout)
+	i.stdout.Buffer(nil, 1024*1024)
+	if err := cmd.Start(); err != nil {
+		i.stdin = nil
+		return err
+	}
+	return nil
+}
+
+// eval evaluates the expression or statement in expr and unmarshals
+// any result into resultVal if resultVal is non-nil.
+func (i *interp) eval(expr string, resultVal interface{}) error {
+	if err := i.start(); err != nil {
+		return fmt.Errorf("cannot start interp: %v", err)
+	}
+	log.Printf("eval: %s", expr)
+	data := make([]byte, base64.StdEncoding.EncodedLen(len(expr))+1)
+	base64.StdEncoding.Encode(data, []byte(expr))
+	data[len(data)-1] = '\n'
+	if _, err := i.stdin.Write(data); err != nil {
+		return err
+	}
+	if !i.stdout.Scan() {
+		if err := i.stdout.Err(); err != nil {
+			return err
+		}
+		return io.ErrUnexpectedEOF
+	}
+	line := i.stdout.Bytes()
+	resultData := make([]byte, base64.StdEncoding.DecodedLen(len(line)))
+	n, err := base64.StdEncoding.Decode(resultData, line)
+	if err != nil {
+		return errgo.Notef(err, "cannot decode base64")
+	}
+	resultData = resultData[0:n]
+	var result struct {
+		Result    json.RawMessage `json:"result"`
+		Exception interface{}     `json:"exception"`
+	}
+	if err := json.Unmarshal(resultData, &result); err != nil {
+		return errgo.Notef(err, "cannot unmarshal result %q", resultData)
+	}
+	if result.Exception != nil {
+		return fmt.Errorf("eval error on %q: %#v", expr, result.Exception)
+	}
+	if resultVal != nil {
+		if err := json.Unmarshal(result.Result, resultVal); err != nil {
+			return fmt.Errorf("cannot unmarshal return result: %v", err)
+		}
+	}
+	return nil
+}

--- a/jsmacaroon.go
+++ b/jsmacaroon.go
@@ -4,23 +4,28 @@
 package macarooncompat
 
 import (
-	"bufio"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
-	"os/exec"
 	"strings"
+
+	errgo "gopkg.in/errgo.v1"
 )
+
+var jsRunner = newJSInterp()
 
 type jsMacaroonPkg struct{}
 
 func (jsMacaroonPkg) New(rootKey []byte, id, loc string) (Macaroon, error) {
 	m := &jsMacaroon{
-		name: newName("m"),
+		name: newJSName("m"),
 	}
-	expr := fmt.Sprintf(`%s = state.macaroon.newMacaroon(%s, %s, %s)`, m.name, jsBits(rootKey), jsVal(id), jsVal(loc))
-	if err := jsEval(expr, nil); err != nil {
+	expr := fmt.Sprintf(`%s = state.macaroon.newMacaroon({
+		rootKey: %s,
+		identifier: %s,
+		location: %s,
+	})`, m.name, jsVal([]byte(rootKey)), jsVal(id), jsVal(loc))
+	if err := jsRunner.eval(expr, nil); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -28,10 +33,10 @@ func (jsMacaroonPkg) New(rootKey []byte, id, loc string) (Macaroon, error) {
 
 func (jsMacaroonPkg) UnmarshalJSON(data []byte) (Macaroon, error) {
 	m := &jsMacaroon{
-		name: newName("m"),
+		name: newJSName("m"),
 	}
-	expr := fmt.Sprintf(`%s = state.macaroon.import(JSON.parse(%s))`, m.name, jsVal(string(data)))
-	if err := jsEval(expr, nil); err != nil {
+	expr := fmt.Sprintf(`%s = state.macaroon.importFromJSONObject(JSON.parse(%s))`, m.name, jsVal(string(data)))
+	if err := jsRunner.eval(expr, nil); err != nil {
 		return m, err
 	}
 	return m, nil
@@ -47,19 +52,19 @@ type jsMacaroon struct {
 
 func (m *jsMacaroon) clone() *jsMacaroon {
 	newm := &jsMacaroon{
-		name: newName("m"),
+		name: newJSName("m"),
 	}
 	expr := fmt.Sprintf(`%s = %s.clone()`, newm.name, m.name)
-	if err := jsEval(expr, nil); err != nil {
+	if err := jsRunner.eval(expr, nil); err != nil {
 		panic(err)
 	}
 	return newm
 }
 
 func (m *jsMacaroon) MarshalJSON() ([]byte, error) {
-	expr := fmt.Sprintf(`JSON.stringify(state.macaroon.export(%s))`, m.name)
+	expr := fmt.Sprintf(`JSON.stringify(%s.exportAsJSONObject())`, m.name)
 	var r string
-	if err := jsEval(expr, &r); err != nil {
+	if err := jsRunner.eval(expr, &r); err != nil {
 		return nil, err
 	}
 	return []byte(r), nil
@@ -73,7 +78,7 @@ func (m *jsMacaroon) WithFirstPartyCaveat(caveatId string) (Macaroon, error) {
 	m = m.clone()
 	expr := fmt.Sprintf(`%s.addFirstPartyCaveat(%s)`,
 		m.name, jsVal(caveatId))
-	if err := jsEval(expr, nil); err != nil {
+	if err := jsRunner.eval(expr, nil); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -82,18 +87,18 @@ func (m *jsMacaroon) WithFirstPartyCaveat(caveatId string) (Macaroon, error) {
 func (m *jsMacaroon) WithThirdPartyCaveat(rootKey []byte, caveatId string, loc string) (Macaroon, error) {
 	m = m.clone()
 	expr := fmt.Sprintf(`%s.addThirdPartyCaveat(%s, %s, %s)`,
-		m.name, jsBits(rootKey), jsVal(caveatId), jsVal(loc))
-	if err := jsEval(expr, nil); err != nil {
+		m.name, jsVal(rootKey), jsVal(caveatId), jsVal(loc))
+	if err := jsRunner.eval(expr, nil); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (m *jsMacaroon) Bind(discharge Macaroon) (Macaroon, error) {
+func (m *jsMacaroon) Bind(primary Macaroon) (Macaroon, error) {
 	m = m.clone()
-	dm := discharge.(*jsMacaroon)
-	expr := fmt.Sprintf(`%s.bind(%s.signature())`, m.name, dm.name)
-	if err := jsEval(expr, nil); err != nil {
+	pm := primary.(*jsMacaroon)
+	expr := fmt.Sprintf(`%s.bind(%s.signature)`, m.name, pm.name)
+	if err := jsRunner.eval(expr, nil); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -111,14 +116,14 @@ func (m *jsMacaroon) Verify(rootKey []byte, check Checker, discharges []Macaroon
 		}
 		return new Error("condition not satisfied")
 	}`, jsVal(check))
-	expr := fmt.Sprintf(`%s.verify(%s, %s, [%s])`, m.name, jsBits(rootKey), checkFunc, strings.Join(dischargeNames, ", "))
-	return jsEval(expr, nil)
+	expr := fmt.Sprintf(`%s.verify(%s, %s, [%s])`, m.name, jsVal(rootKey), checkFunc, strings.Join(dischargeNames, ", "))
+	return jsRunner.eval(expr, nil)
 }
 
 func (m *jsMacaroon) Signature() []byte {
-	expr := fmt.Sprintf(`state.sjcl.codec.base64.fromBits(%s.signature())`, m.name)
+	expr := fmt.Sprintf(`state.btoa(String.fromCharCode.apply(null, %s.signature))`, m.name)
 	var r string
-	err := jsEval(expr, &r)
+	err := jsRunner.eval(expr, &r)
 	if err != nil {
 		panic(fmt.Errorf("cannot get signature: %v", err))
 	}
@@ -131,104 +136,65 @@ func (m *jsMacaroon) Signature() []byte {
 
 var jsNameSeq = 0
 
-func newName(s string) string {
+func newJSName(s string) string {
 	n := jsNameSeq
 	jsNameSeq++
 	return fmt.Sprintf("state.%s%d", s, n)
 }
 
-func jsBits(data []byte) string {
-	return fmt.Sprintf(`state.sjcl.codec.base64.toBits(%q)`, base64.StdEncoding.EncodeToString(data))
-}
-
-func jsVal(x interface{}) []byte {
-	data, err := json.Marshal(x)
-	if err != nil {
-		panic(err)
+func jsVal(v interface{}) string {
+	switch v := v.(type) {
+	case []byte:
+		return fmt.Sprintf(`state.b64toUint8array(%q)`, base64.StdEncoding.EncodeToString(v))
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			panic(err)
+		}
+		return string(data)
 	}
-	return data
 }
 
-var (
-	jsStdin  io.Writer
-	jsStdout *bufio.Scanner
-)
+type jsInterp struct {
+	interp *interp
+}
 
-func jsStart() error {
-	if jsStdin != nil {
+func newJSInterp() *jsInterp {
+	return &jsInterp{
+		interp: newInterp("js/interp.js"),
+	}
+}
+
+func (i *jsInterp) start() error {
+	if i.interp.started() {
 		return nil
 	}
-	cmd := exec.Command("js/interp.js")
-	var err error
-	jsStdin, err = cmd.StdinPipe()
-	if err != nil {
-		return err
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	jsStdout = bufio.NewScanner(stdout)
-	if err := cmd.Start(); err != nil {
-		return err
+	if err := i.interp.start(); err != nil {
+		return errgo.Mask(err)
 	}
 	// Check that it's working.
 	var r bool
-	if err := jsEval("true;", &r); err != nil {
-		jsStdin = nil
-		jsStdout = nil
+	if err := i.interp.eval("true;", &r); err != nil {
 		return fmt.Errorf("sanity check failed: %v", err)
 	}
-	if err := jsEval(`state.macaroon = require("macaroon")`, nil); err != nil {
-		jsStdin = nil
-		jsStdout = nil
-		return fmt.Errorf("cannot require macaroon library: %v", err)
+	for _, r := range []string{"macaroon", "atob", "btoa"} {
+		if err := i.interp.eval(fmt.Sprintf(`state.%s = require(%q)`, r, r), nil); err != nil {
+			return fmt.Errorf("cannot require %s: %v", r, err)
+		}
 	}
-	if err := jsEval(`state.sjcl = require("sjcl")`, nil); err != nil {
-		jsStdin = nil
-		jsStdout = nil
-		return fmt.Errorf("cannot require sjcl libary: %v", err)
+	if err := i.interp.eval(`state.b64toUint8array = function(b64) {
+		return new Uint8Array(state.atob(b64).split("").map(function(c) {
+			return c.charCodeAt(0);
+		}));
+	}`, nil); err != nil {
+		return fmt.Errorf("cannot define b64toUint8array")
 	}
 	return nil
 }
 
-func jsEval(expr string, resultVal interface{}) error {
-	if err := jsStart(); err != nil {
+func (i *jsInterp) eval(expr string, resultVal interface{}) error {
+	if err := i.start(); err != nil {
 		return fmt.Errorf("cannot start jsinterp: %v", err)
 	}
-	data := make([]byte, base64.StdEncoding.EncodedLen(len(expr))+1)
-	base64.StdEncoding.Encode(data, []byte(expr))
-	data[len(data)-1] = '\n'
-	if _, err := jsStdin.Write(data); err != nil {
-		return err
-	}
-	if !jsStdout.Scan() {
-		if err := jsStdout.Err(); err != nil {
-			return err
-		}
-		return io.ErrUnexpectedEOF
-	}
-	line := jsStdout.Bytes()
-	resultData := make([]byte, base64.StdEncoding.DecodedLen(len(line)))
-	n, err := base64.StdEncoding.Decode(resultData, line)
-	if err != nil {
-		return err
-	}
-	resultData = resultData[0:n]
-	var result struct {
-		Result    json.RawMessage `json:"result"`
-		Exception string          `json:"exception"`
-	}
-	if err := json.Unmarshal(resultData, &result); err != nil {
-		return err
-	}
-	if result.Exception != "" {
-		return fmt.Errorf("eval error on %q: %s", expr, result.Exception)
-	}
-	if resultVal != nil {
-		if err := json.Unmarshal(result.Result, resultVal); err != nil {
-			return fmt.Errorf("cannot unmarshal return result: %v", err)
-		}
-	}
-	return nil
+	return i.interp.eval(expr, resultVal)
 }

--- a/libmacaroons.go
+++ b/libmacaroons.go
@@ -4,85 +4,169 @@
 package macarooncompat
 
 import (
-	"github.com/rescrv/libmacaroons/bindings/go/macaroons"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	errgo "gopkg.in/errgo.v1"
 )
 
+var libMacaroonsRunner = []*libMacaroonsInterp{
+	2: newLibMacaroonsInterp(2),
+	3: newLibMacaroonsInterp(3),
+}
+
+type libMacaroonsPkg struct {
+	version int
+}
+
+func (p libMacaroonsPkg) eval(expr string, result interface{}) error {
+	return libMacaroonsRunner[p.version].eval(expr, result)
+}
+
+func (p libMacaroonsPkg) New(rootKey []byte, id, loc string) (Macaroon, error) {
+	m := p.newMacaroon()
+	expr := fmt.Sprintf(`%s = macaroons.create(%s, %s, %s)`,
+		m.name, pyVal(loc), pyVal(rootKey), pyVal(id))
+	if err := p.eval(expr, nil); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (p libMacaroonsPkg) newMacaroon() *libMacaroon {
+	return &libMacaroon{
+		p:    p,
+		name: newPyName("m"),
+	}
+}
+
+func (p libMacaroonsPkg) UnmarshalJSON(data []byte) (Macaroon, error) {
+	m := p.newMacaroon()
+	expr := fmt.Sprintf(`%s = macaroons.deserialize(%s)`, m.name, pyVal(base64.StdEncoding.EncodeToString(data)))
+	if err := p.eval(expr, nil); err != nil {
+		return m, err
+	}
+	return m, nil
+}
+
+func (p libMacaroonsPkg) UnmarshalBinary(data []byte) (Macaroon, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
 type libMacaroon struct {
-	*macaroons.Macaroon
+	p    libMacaroonsPkg
+	name string
 }
 
-func (m libMacaroon) Clone() libMacaroon {
-	newm, err := m.Macaroon.Copy()
-	if err != nil {
-		panic(err)
-	}
-	return libMacaroon{newm}
-}
-
-func (m libMacaroon) WithFirstPartyCaveat(caveatId string) (Macaroon, error) {
-	m = m.Clone()
-	if err := m.Macaroon.WithFirstPartyCaveat(caveatId); err != nil {
+func (m *libMacaroon) MarshalJSON() ([]byte, error) {
+	expr := fmt.Sprintf(`result = %s.serialize(format='2j')`, m.name)
+	var r string
+	if err := m.p.eval(expr, &r); err != nil {
 		return nil, err
 	}
-	return m, nil
+	return []byte(r), nil
 }
 
-func (m libMacaroon) Signature() []byte {
-	return []byte(m.Macaroon.Signature())
+func (m *libMacaroon) MarshalBinary() ([]byte, error) {
+	return nil, fmt.Errorf("unimplemented")
 }
 
-func (m libMacaroon) WithThirdPartyCaveat(rootKey []byte, caveatId string, loc string) (Macaroon, error) {
-	m = m.Clone()
-	if err := m.Macaroon.WithThirdPartyCaveat(loc, string(rootKey), caveatId); err != nil {
+func (m *libMacaroon) WithFirstPartyCaveat(caveatId string) (Macaroon, error) {
+	m1 := m.p.newMacaroon()
+	expr := fmt.Sprintf(`%s = %s.add_first_party_caveat(%s)`,
+		m1.name, m.name, pyVal(caveatId))
+	if err := m.p.eval(expr, nil); err != nil {
 		return nil, err
 	}
-	return m, nil
+	return m1, nil
 }
 
-func (m libMacaroon) Bind(primary Macaroon) (Macaroon, error) {
-	m1, err := primary.(libMacaroon).PrepareForRequest(m.Macaroon)
-	if err != nil {
+func (m *libMacaroon) WithThirdPartyCaveat(rootKey []byte, caveatId string, loc string) (Macaroon, error) {
+	m1 := m.p.newMacaroon()
+	// TODO specify nonce explicitly.
+	expr := fmt.Sprintf(`%s = %s.add_third_party_caveat(%s, %s, %s)`,
+		m1.name, m.name, pyVal(loc), pyVal(rootKey), pyVal(caveatId))
+	if err := m.p.eval(expr, nil); err != nil {
 		return nil, err
 	}
-	return libMacaroon{m1}, nil
+	return m1, nil
 }
 
-func (m libMacaroon) Verify(rootKey []byte, check Checker, discharges []Macaroon) error {
-	discharges1 := make([]*macaroons.Macaroon, len(discharges))
+func (m *libMacaroon) Bind(primary Macaroon) (Macaroon, error) {
+	pm := primary.(*libMacaroon)
+	boundM := m.p.newMacaroon()
+	expr := fmt.Sprintf(`%s = %s.prepare_for_request(%s)`, boundM.name, pm.name, m.name)
+	if err := m.p.eval(expr, nil); err != nil {
+		return nil, err
+	}
+	return boundM, nil
+}
+
+func (m *libMacaroon) Verify(rootKey []byte, check Checker, discharges []Macaroon) error {
+	dischargeNames := make([]string, len(discharges))
 	for i, m := range discharges {
-		discharges1[i] = m.(libMacaroon).Macaroon
+		dischargeNames[i] = m.(*libMacaroon).name
 	}
-	v := macaroons.NewVerifier()
-	if err := v.SatisfyGeneral(func(caveat string) bool {
-		return check[caveat]
-	}); err != nil {
-		return err
-	}
-	return v.Verify(m.Macaroon, string(rootKey), discharges1...)
+	checkData, _ := json.Marshal(check)
+	expr := fmt.Sprintf(`bool_verifier(json.loads(%s)).verify(%s, %s, [%s])`, pyVal(string(checkData)), m.name, pyVal(rootKey), strings.Join(dischargeNames, ", "))
+	return m.p.eval(expr, nil)
 }
 
-type libMacaroonPkg struct{}
-
-func (libMacaroonPkg) UnmarshalJSON(data []byte) (Macaroon, error) {
-	var m macaroons.Macaroon
-	if err := m.UnmarshalJSON(data); err != nil {
-		return nil, err
-	}
-	return libMacaroon{&m}, nil
-}
-
-func (libMacaroonPkg) UnmarshalBinary(data []byte) (Macaroon, error) {
-	var m macaroons.Macaroon
-	if err := m.UnmarshalBinary(data); err != nil {
-		return nil, err
-	}
-	return libMacaroon{&m}, nil
-}
-
-func (libMacaroonPkg) New(rootKey []byte, id, loc string) (Macaroon, error) {
-	m, err := macaroons.NewMacaroon(loc, string(rootKey), id)
+func (m *libMacaroon) Signature() []byte {
+	expr := fmt.Sprintf(`result = %s.signature`, m.name)
+	var r string
+	err := m.p.eval(expr, &r)
 	if err != nil {
-		return nil, err
+		panic(fmt.Errorf("cannot get signature: %v", err))
 	}
-	return libMacaroon{m}, nil
+	data, err := hex.DecodeString(r)
+	if err != nil {
+		panic(fmt.Errorf("cannot decode base64 signature: %v", err))
+	}
+	return data
+}
+
+type libMacaroonsInterp struct {
+	interp *pyInterp
+}
+
+func newLibMacaroonsInterp(version int) *libMacaroonsInterp {
+	return &libMacaroonsInterp{
+		interp: newPyInterp(version),
+	}
+}
+
+func (i *libMacaroonsInterp) eval(expr string, resultVal interface{}) error {
+	if err := i.start(); err != nil {
+		return fmt.Errorf("cannot start pyinterp: %v", err)
+	}
+	return i.interp.eval(expr, resultVal)
+}
+
+func (i *libMacaroonsInterp) start() error {
+	if i.interp.started() {
+		return nil
+	}
+	if err := i.interp.start(); err != nil {
+		return errgo.Mask(err)
+	}
+	for _, p := range []string{"macaroons", "base64", "json"} {
+		if err := i.interp.eval(fmt.Sprintf("global %s; import %s", pyImportSym(p), p), nil); err != nil {
+			return errgo.Notef(err, "cannot import %s", p)
+		}
+	}
+	boolVerifierDef := `
+global bool_verifier
+def bool_verifier(conds):
+	v = macaroons.Verifier()
+	v.satisfy_general(lambda cond: conds.get(cond, None))
+	return v
+`
+	if err := i.interp.eval(boolVerifierDef, nil); err != nil {
+		return errgo.Notef(err, "cannot define bool_verifier")
+	}
+	return nil
 }

--- a/pymacaroons.go
+++ b/pymacaroons.go
@@ -1,0 +1,187 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPL, see LICENCE file for details.
+
+package macarooncompat
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	errgo "gopkg.in/errgo.v1"
+)
+
+var pyMacaroonsRunner = []*pyMacaroonsInterp{
+	2: newPyMacaroonsInterp(2),
+	3: newPyMacaroonsInterp(3),
+}
+
+type pyMacaroonsPkg struct {
+	version int
+}
+
+func (p pyMacaroonsPkg) eval(expr string, result interface{}) error {
+	return pyMacaroonsRunner[p.version].eval(expr, result)
+}
+
+func (p pyMacaroonsPkg) New(rootKey []byte, id, loc string) (Macaroon, error) {
+	m := p.newMacaroon()
+	expr := fmt.Sprintf(`%s = pymacaroons.Macaroon(location=%s, identifier=%s, key=%s)`,
+		m.name, pyVal(loc), pyVal(id), pyVal(rootKey))
+	if err := p.eval(expr, nil); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (p pyMacaroonsPkg) newMacaroon() *pyMacaroon {
+	return &pyMacaroon{
+		p:    p,
+		name: newPyName("m"),
+	}
+}
+
+func (p pyMacaroonsPkg) UnmarshalJSON(data []byte) (Macaroon, error) {
+	m := p.newMacaroon()
+	expr := fmt.Sprintf(`%s = pymacaroons.Macaroon.deserialize(%s, serializer=pymacaroons.serializers.JsonSerializer())`, m.name, pyVal(string(data)))
+	if err := p.eval(expr, nil); err != nil {
+		return m, err
+	}
+	return m, nil
+}
+
+func (p pyMacaroonsPkg) UnmarshalBinary(data []byte) (Macaroon, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+type pyMacaroon struct {
+	p    pyMacaroonsPkg
+	name string
+}
+
+func (m *pyMacaroon) clone() *pyMacaroon {
+	newm := m.p.newMacaroon()
+	expr := fmt.Sprintf(`%s = %s.copy()`, newm.name, m.name)
+	if err := m.p.eval(expr, nil); err != nil {
+		panic(err)
+	}
+	return newm
+}
+
+func (m *pyMacaroon) MarshalJSON() ([]byte, error) {
+	expr := fmt.Sprintf(`result = %s.serialize(pymacaroons.serializers.JsonSerializer())`,
+		m.name)
+	var r string
+	if err := m.p.eval(expr, &r); err != nil {
+		return nil, err
+	}
+	return []byte(r), nil
+}
+
+func (m *pyMacaroon) MarshalBinary() ([]byte, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+func (m *pyMacaroon) WithFirstPartyCaveat(caveatId string) (Macaroon, error) {
+	m = m.clone()
+	expr := fmt.Sprintf(`%s.add_first_party_caveat(%s)`,
+		m.name, pyVal(caveatId))
+	if err := m.p.eval(expr, nil); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m *pyMacaroon) WithThirdPartyCaveat(rootKey []byte, caveatId string, loc string) (Macaroon, error) {
+	m = m.clone()
+	// Read the nonce explicitly from crypto/rand so that it can
+	// be patched by the tests
+	nonce := make([]byte, 24)
+	if _, err := rand.Read(nonce[:]); err != nil {
+		panic(err)
+	}
+	expr := fmt.Sprintf(`%s.add_third_party_caveat(%s, %s, %s, nonce=%s)`,
+		m.name, pyVal(loc), pyVal(rootKey), pyVal(caveatId), pyVal(nonce))
+	if err := m.p.eval(expr, nil); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m *pyMacaroon) Bind(primary Macaroon) (Macaroon, error) {
+	pm := primary.(*pyMacaroon)
+	boundM := m.p.newMacaroon()
+	expr := fmt.Sprintf(`%s = %s.prepare_for_request(%s)`, boundM.name, pm.name, m.name)
+	if err := m.p.eval(expr, nil); err != nil {
+		return nil, err
+	}
+	return boundM, nil
+}
+
+func (m *pyMacaroon) Verify(rootKey []byte, check Checker, discharges []Macaroon) error {
+	dischargeNames := make([]string, len(discharges))
+	for i, m := range discharges {
+		dischargeNames[i] = m.(*pyMacaroon).name
+	}
+	checkData, _ := json.Marshal(check)
+	expr := fmt.Sprintf(`bool_verifier(json.loads(%s)).verify(%s, %s, [%s])`, pyVal(string(checkData)), m.name, pyVal(rootKey), strings.Join(dischargeNames, ", "))
+	return m.p.eval(expr, nil)
+}
+
+func (m *pyMacaroon) Signature() []byte {
+	expr := fmt.Sprintf(`result = %s.signature`, m.name)
+	var r string
+	err := m.p.eval(expr, &r)
+	if err != nil {
+		panic(fmt.Errorf("cannot get signature: %v", err))
+	}
+	data, err := hex.DecodeString(r)
+	if err != nil {
+		panic(fmt.Errorf("cannot decode base64 signature: %v", err))
+	}
+	return data
+}
+
+type pyMacaroonsInterp struct {
+	interp *pyInterp
+}
+
+func newPyMacaroonsInterp(version int) *pyMacaroonsInterp {
+	return &pyMacaroonsInterp{
+		interp: newPyInterp(version),
+	}
+}
+
+func (i *pyMacaroonsInterp) eval(expr string, resultVal interface{}) error {
+	if err := i.start(); err != nil {
+		return fmt.Errorf("cannot start pyinterp: %v", err)
+	}
+	return i.interp.eval(expr, resultVal)
+}
+
+func (i *pyMacaroonsInterp) start() error {
+	if i.interp.started() {
+		return nil
+	}
+	if err := i.interp.start(); err != nil {
+		return errgo.Mask(err)
+	}
+	for _, p := range []string{"pymacaroons", "base64", "pymacaroons.serializers", "json"} {
+		if err := i.interp.eval(fmt.Sprintf("global %s; import %s", pyImportSym(p), p), nil); err != nil {
+			return errgo.Notef(err, "cannot import %s", p)
+		}
+	}
+	boolVerifierDef := `
+global bool_verifier
+def bool_verifier(conds):
+	v = pymacaroons.Verifier()
+	v.satisfy_general(lambda cond: conds.get(cond, None))
+	return v
+`
+	if err := i.interp.eval(boolVerifierDef, nil); err != nil {
+		return errgo.Notef(err, "cannot define bool_verifier")
+	}
+	return nil
+}

--- a/python/interp.py
+++ b/python/interp.py
@@ -1,0 +1,40 @@
+import base64
+import json
+import os
+import six
+import sys
+import traceback
+
+# we define our own StringIO object because StringIO.StringIO isn't
+# available in Python 3 but io.StringIO in Python 2 raises an exception
+# if a non-unicode string is passed to the write method, so it can't be
+# used with traceback.print_exc
+class StringIO(object):
+	def __init__(self):
+		self.s = ''
+
+	def write(self, s):
+		self.s += s
+
+	def getvalue(self):
+		return self.s
+
+vars={}
+while True:
+	line=sys.stdin.readline()
+	if line == "":
+		break
+	result={}
+	try:
+		vars["result"] = None
+		six.exec_(base64.b64decode(line), globals(), vars)
+		result["result"] = vars["result"]
+	except:
+		f = StringIO()
+		traceback.print_exc(file=f)
+		result["exception"] = f.getvalue()
+	out = json.dumps(result)
+	send = base64.b64encode(out.encode('utf-8')).decode('utf-8') + '\n'
+	sys.stdout.write(send)
+	sys.stdout.flush()
+


### PR DESCRIPTION
Also change the libmacaroons tests to use the python wrapper
so we don't need to use cgo, and update the js-macaroon tests
to use the latest version.

To QA:

- install js-macaroon:

    npm install macaroon

- install pymacaroons (requires fixed version, pending https://github.com/ecordell/pymacaroons/issues/37 fix):

    pip install pymacaroons

Then:

   go test
